### PR TITLE
Simplify CI to a single build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20.x, 22.x]
-
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn lint


### PR DESCRIPTION
This change simplifies the GitHub Actions CI workflow by removing the matrix strategy that tested against multiple Node.js versions (20.x and 22.x). It now consistently uses Node.js 22 for a single build job, which includes linting, formatting checks, tests, and building.

---
*PR created automatically by Jules for task [2402655262830042837](https://jules.google.com/task/2402655262830042837) started by @allemandi*